### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/checkmate/contrib/plugins/git/lib/repository.py
+++ b/checkmate/contrib/plugins/git/lib/repository.py
@@ -140,19 +140,19 @@ class Repository(object):
                 start_time = time.time()
                 
                 while time.time() - start_time < timeout:
-                    if p.poll() != None:
+                    if p.poll() is not None:
                         break
                     time.sleep(0.001)               
 
                 timeout_occured = False
 
-                if p.poll() == None:
+                if p.poll() is None:
                     timeout_occured = True
                     stdout.flush()
                     stderr.flush()
                     p.terminate()
                     time.sleep(0.1)
-                    if p.poll() == None:
+                    if p.poll() is None:
                         p.kill()
 
                 read_output()
@@ -443,7 +443,7 @@ class Repository(object):
         return n_commits
 
     def get_files_in_commit(self,commit_sha,path = None):
-        if path == None:
+        if path is None:
             opts = ["--full-tree","-r",commit_sha]
         else:
             opts = ["%s:%s" % (commit_sha,path)]


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:programmdesign:checkmate?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:programmdesign:checkmate?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
